### PR TITLE
[WIP] Show line numbers of instructions in log lines

### DIFF
--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -11,6 +11,7 @@ import logging
 log = logging.getLogger(__name__)
 
 class TTXParseError(Exception): pass
+class StringWithLineNumber(unicode): pass
 
 BUFSIZE = 0x4000
 
@@ -56,6 +57,7 @@ class XMLReader(object):
 		parser.StartElementHandler = self._startElementHandler
 		parser.EndElementHandler = self._endElementHandler
 		parser.CharacterDataHandler = self._characterDataHandler
+		self.parser = parser
 
 		pos = 0
 		while True:
@@ -125,6 +127,8 @@ class XMLReader(object):
 
 	def _characterDataHandler(self, data):
 		if self.stackSize > 1:
+			data = StringWithLineNumber(data)
+			data.lineNumber = self.parser.CurrentLineNumber
 			self.contentStack[-1].append(data)
 
 	def _endElementHandler(self, name):

--- a/Lib/fontTools/ttLib/instructions/abstractExecute.py
+++ b/Lib/fontTools/ttLib/instructions/abstractExecute.py
@@ -1152,9 +1152,9 @@ class Executor(object):
         while self.current_instruction is not None:
             logger.info("     program_stack is %s" % (str(map(lambda s:s.eval(False), self.environment.program_stack))))
             if self.current_instruction.data is not None:
-                logger.info("[pc] %s->%s|%s",self.current_instruction.id, self.current_instruction.mnemonic,map(lambda x:x.value, self.current_instruction.data))
+                logger.info("[pc] [%d] %s->%s|%s",self.current_instruction.lineNumber,self.current_instruction.id, self.current_instruction.mnemonic,map(lambda x:x.value, self.current_instruction.data))
             else:
-                logger.info("[pc] %s->%s",self.current_instruction.id,self.current_instruction.mnemonic)
+                logger.info("[pc] [%d] %s->%s",self.current_instruction.lineNumber,self.current_instruction.id,self.current_instruction.mnemonic)
             logger.info("     succs are %s", self.current_instruction.successors)
             logger.info("     call_stack len is %s", len(self.call_stack))
 

--- a/Lib/fontTools/ttLib/instructions/instructionConstructor.py
+++ b/Lib/fontTools/ttLib/instructions/instructionConstructor.py
@@ -32,6 +32,8 @@ class instructionConstructor():
                     break
             if has_data:
                 self.typed_instruction.add_data(Data(data))
+        if hasattr(self.instruction, "lineNumber"):
+            self.typed_instruction.lineNumber = self.instruction.lineNumber
     def construct(self,idClasses, builderName):
         targetClass = getattr(idClasses, builderName)
         return targetClass()


### PR DESCRIPTION
I think this can be merged eventually, but a few changes need to be made to make it more robust.

Todo:
- [ ] Have it not crash on `.ttf` files
- [ ] The line number for data lines ins't used later on, so maybe that shouldn't be stored with it.